### PR TITLE
enable multiple config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ venv*/
 install.log
 jarjar-shell
 build/
+.jarjar

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,17 +10,31 @@ pip install jarjar
 
 ## Config File
 
-You can use jarjar without a config file, but you'll need to tell it your slack webhook and channel each time.
+You can use jarjar without a config file, but you'll need to tell it your slack
+webhook and channel each time.
 
 You don't want to live that way.
 
-Jarjar looks for a special file in your user home `~/.jarjar` for default webhook, channel, and/or message. You can over-ride anything in there pretty much any time you want.
+Jarjar looks to a special config file for a default webhook, channel, and
+message values. You can over-ride anything in the config file any time but its
+nice not to have your webhook in each script, amirite??
+
+The file looks like:
 
 ```sh
 channel='@username'
 message='Custom message'
 webhook='https://hooks.slack.com/services/your/teams/webhook'
 ```
+
+Jarjar looks for values in descending order of priority:
+
+1. Any argument provided to `jarjar().text()` or `jarjar().attach()` at runtime.
+2. Any argument provided to `jarjar()` at initialization.
+3. Defaults within a file at a user-specified path (`config='...'`), provided to
+   `jarjar()` at initialization.
+4. Defaults within a config file ``.jarjar``, in the working directory.
+5. Defaults within ``.jarjar``, located in the user's home directory (`~`).
 
 ## Configuring Slack
 

--- a/jarjar/jarjar.py
+++ b/jarjar/jarjar.py
@@ -58,7 +58,8 @@ class jarjar(object):
     1. Any argument provided to :func:`~jarjar.jarjar.text` or
        :func:`~jarjar.jarjar.attach` supersedes all defaults.
     2. Any argument provided to this class at initialization.
-    3. Defaults within a config file at a user-specified path (``config='...').
+    3. Defaults within a config file at a user-specified path
+       (``config='...'``).
     4. Defaults within a config file ``.jarjar``, within the working directory.
     5. Defaults within ``.jarjar``, located in the user's home directory.
 
@@ -70,10 +71,12 @@ class jarjar(object):
         message="Custom message"
         webhook="https://hooks.slack.com/services/your/teams/webhook"
 
-    3. Arguments provided  at initialization supersede those in ``~/.jarjar``.
-       If the channel or webhook arguments are never provided, an error is
-       raised. If the channel and webhook are provided but not a message or
-       attachment, jarjar will make something up.
+    If the channel or webhook arguments are never provided, an error is
+    raised. If the channel and webhook are provided but not a message or
+    attachment, jarjar will make something up.
+
+    If a value is found in multiple places, the value from the highest priority
+    location is used.
 
     Methods
     -------
@@ -90,6 +93,9 @@ class jarjar(object):
 
     Parameters
     ----------
+    config : str, list
+        Optional. Path(s) to jarjar configuration file(s). If a list,
+        configs should be in descending order of priority.
     message : str
         Optional. Default message to send.
     channel : str,  list
@@ -129,8 +135,7 @@ class jarjar(object):
 
         # add inline defaults to the front
         configs.insert(0, defaults)
-        for i in configs:
-            print(i)
+
         # set attrs
         for val in _EXPECTED_CONFIG:
             setattr(

--- a/tests/test-config-reader.py
+++ b/tests/test-config-reader.py
@@ -1,0 +1,7 @@
+from jarjar import jarjar
+jj = jarjar(config='../.jarjar', message='hello2')
+print(jj.default_channel)
+print(jj.default_message)
+print(jj.default_webhook)
+
+# jj.text()


### PR DESCRIPTION
To enable multiple config files, the importing of defaults had to
change. Now, there is a separate function `read_config_file` which
accepts a path and extracts the config as a dictionary. jarjar
configuration is extracted from expected locations (working dir; ~)
and a list of configuration is constructed in order of source
priority:

1. as kwargs to __init__
2. From a user-defined file path
3. Local .jarjar file
4. Use home ~/.jarjar file